### PR TITLE
Fixed Object Detection API Library Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ All remaining operations should be done from the root user.
 # cd /opt
 # git clone https://github.com/tensorflow/models
 # cd models
-# protoc object_detection/protos/*.proto --python_out=.
+# protoc research/object_detection/protos/*.proto --python_out=.
 ```
 
 ## Download the pretrained model binaries


### PR DESCRIPTION
This commit fixes the path in the instructions for installing the Object Detection Library API. The path changed due to some restructuring in the tensorfloe/models repo. Another patch has been submitted to tensorflow/models that fixes the paths inside the proto files.