### PR TITLE
feat(app): add ability to run in docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,7 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# model files
+*.pb
+*.pbtxt

--- a/object_detection_app/Dockerfile
+++ b/object_detection_app/Dockerfile
@@ -1,0 +1,7 @@
+FROM object-detection-core
+MAINTAINER Josh Kurz <jkurz25@gmail.com>
+
+# APPLICATION
+ADD . /opt/object_detection/
+
+CMD ["/usr/bin/python", "/opt/object_detection/app.py"]

--- a/object_detection_app/Dockerfile.core
+++ b/object_detection_app/Dockerfile.core
@@ -1,0 +1,39 @@
+############################################################
+# Dockerfile to build uwsgi using python3 container images
+# Based on Ubuntu 14.04.4
+############################################################
+
+FROM ubuntu:14.04.4
+MAINTAINER Josh Kurz <jkurz25@gmail.com>
+
+# python 3.4 has already installed
+RUN apt-get update && \
+    apt-get install -y python-pip \
+    python-pil \
+    python-lxml \
+    git \
+    wget \
+    unzip
+
+# clean apt-get
+RUN apt-get autoclean && \
+    apt-get clean && \
+    apt-get autoremove
+
+# update pip
+RUN pip install -U pip setuptools
+
+# INSTALL requirements before for caching
+COPY requirements.txt /var/app/requirements.txt
+
+# install requirements
+RUN pip install -r /var/app/requirements.txt
+
+WORKDIR /opt/
+
+RUN git clone https://github.com/tensorflow/models
+RUN  wget https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-linux-x86_64.zip \
+     && chmod 775 protoc-3.3.0-linux-x86_64.zip \
+     && unzip protoc-3.3.0-linux-x86_64.zip \
+     && mv bin/protoc /usr/bin/
+RUN cd models/research && protoc object_detection/protos/*.proto --python_out=.

--- a/object_detection_app/docker-compose.yml
+++ b/object_detection_app/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "2"
+services:
+  object_detection:
+    image: object-detection-docker
+    ports:
+    - 80:80
+    volumes:
+    - ../frozen_inference_graph.pb:/opt/graph_def/frozen_inference_graph.pb
+    - ../label_map.pbtxt:/opt/models/research/object_detection/data/mscoco_label_map.pbtxt
+    environment:
+      THRESHOLD: 0.6
+      DEBUG: "True"
+      NUM_CLASSES: 1
+      PYTHONUNBUFFERED: 1

--- a/object_detection_app/requirements.txt
+++ b/object_detection_app/requirements.txt
@@ -1,0 +1,6 @@
+Flask==0.12.2
+WTForms==2.1
+Flask_WTF==0.14.2
+Werkzeug==0.12.2
+tensorflow
+Pillow


### PR DESCRIPTION
* add ability to run application in docker

This simplifies the learning curve of running models that were build using the object detection api examples. If this is something that you would want to merge in I could add some Readme docs as well. I also didn't touch the app.py because I didn't want to possibly mess up other installations people have done with this example. 