### PR TITLE
Avoid errors with models whose name contains dots

### DIFF
--- a/object_detection_app_p3/app.py
+++ b/object_detection_app_p3/app.py
@@ -94,7 +94,7 @@ class ObjectDetector(object):
     model_url = MODEL_URL
     base_url = os.path.dirname(model_url)+"/"
     model_file = os.path.basename(model_url)
-    model_name = model_file.split('.')[0]
+    model_name = os.path.splitext(os.path.splitext(model_file)[0])[0]
     model_dir = tf.keras.utils.get_file(
         fname=model_name, origin=base_url + model_file, untar=True)
     model_dir = pathlib.Path(model_dir)/"saved_model"


### PR DESCRIPTION
Some models in the COCO-trained models contains dots in their names. For example, `ssd_mobilenet_v1_0.75_depth_300x300_coco14_sync_2018_07_03` contains a dot (`0.75`). The current implementation can't handle this type of model names properly and raises OSError exception:

```
Downloading data from http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_0.75_depth_300x300_coco14_sync_2018_07_03.tar.gz
46571520/46564655 [==============================] - 5s 0us/step
Traceback (most recent call last):
  File "/opt/object_detection_app_p3/app.py", line 192, in <module>
    client = ObjectDetector()
  File "/opt/object_detection_app_p3/app.py", line 103, in __init__
    model = tf.saved_model.load(str(model_dir))
  File "/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/saved_model/load.py", line 517, in load
    return load_internal(export_dir, tags)
  File "/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/saved_model/load.py", line 526, in load_internal
    saved_model_proto = loader_impl.parse_saved_model(export_dir)
  File "/usr/local/lib/python3.6/dist-packages/tensorflow_core/python/saved_model/loader_impl.py", line 83, in parse_saved_model
    constants.SAVED_MODEL_FILENAME_PB))
OSError: SavedModel file does not exist at: /root/.keras/datasets/ssd_mobilenet_v1_0/saved_model/{saved_model.pbtxt|saved_model.pb}
```

This patch fixes this bug by calling `os.path.splitext()` twice because all the names of the COCO-trained model files end with ".tar.gz".